### PR TITLE
Fix CVE-2024-LODASH: Update lodash to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.17.1",
-    "lodash": "4.17.19",
+    "lodash": "4.17.21",
     "request": "2.88.0",
     "axios": "0.21.0",
     "moment": "2.29.1",


### PR DESCRIPTION
## Vulnerability
lodash 4.17.19 has prototype pollution vulnerability

## Fix
Update to 4.17.21



🤖 Generated by GitHub PR Handler - SIGINT-4748 Test