### PR TITLE
Fix CVE-2024-AXIOS: Update axios to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "4.17.1",
     "lodash": "4.17.19",
     "request": "2.88.0",
-    "axios": "0.21.0",
+    "axios": "1.6.0",
     "moment": "2.29.1",
     "mysql": "2.18.1",
     "jsonwebtoken": "8.5.1",


### PR DESCRIPTION
## Vulnerability
axios 0.21.0 has security issues

## Fix
Update to 1.6.0



🤖 Generated by GitHub PR Handler - SIGINT-4748 Test